### PR TITLE
fixed bug causing last bin in root histo to be wrong

### DIFF
--- a/include/bayesian_blocks_root.hpp
+++ b/include/bayesian_blocks_root.hpp
@@ -75,9 +75,9 @@ namespace BayesianBlocks {
             auto bin = h_out->FindBin(h_in->GetBinCenter(b));
             h_out->SetBinContent(bin, h_out->GetBinContent(bin) + c);
         }
-        h_out->SetBinContent(0, h_in->GetBinContent(0));
-        h_out->SetBinContent(result.size()-1, h_in->GetBinContent(h_in->GetNbinsX()));
-        h_out->Scale(1, "width");
+        h_out->SetBinContent(0, h_in->GetBinContent(0));                                  //underflow bin
+        h_out->SetBinContent(result.size(), h_in->GetBinContent(h_in->GetNbinsX()));      //overflow bin
+        h_out->Scale(1, "width");       //divide values and errors by bin widths
 
         return h_out;
     }


### PR DESCRIPTION
Last histogram-bin of output was erroneously overwritten by overflow bin of input. 